### PR TITLE
Copy instead of symlink by default

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,33 @@
 # Author(s): Raghav Kansal
 #############################################################
 
+EDITABLE=0  # editable installation of customizations? Cannot then be tarballed for condor jobs 
+            # (crab jobs still work because of better tar-ing https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#What_are_the_files_CRAB_adds_to)
+
+options=$(getopt -o "e" --long "editable" -- "$@")
+eval set -- "$options"
+
+while true; do
+    case "$1" in
+        -e|--editable)
+            EDITABLE=1
+            ;;
+        --)
+            shift
+            break;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+
 CMSSW_VER=CMSSW_14_0_6_patch1
 this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
 this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
@@ -46,10 +73,15 @@ if ! [ -f "$this_dir/cmssw/$CMSSW_VER/.installed" ]; then
       run_cmd wget https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles/raw/refs/heads/deepTau_v2p5_noDomainAdaptation/DeepTauId/deepTau_2018v2p5_noDomainAdaptation_{core,inner,outer}.pb -P RecoTauTag/TrainingFiles/data/DeepTauId/
     fi
 
-    # custom code
+    # custom code. 
+    #if EDITABLE, will link instead of copying (but this breaks tarballing for condor jobs)
     # not sure why, but this directory structure is necessary...
     run_cmd mkdir -p DAZSLE/DAZSLE
-    run_cmd ln -s "$this_dir/customizations" DAZSLE/DAZSLE/python
+    if [ $EDITABLE -eq 0 ]; then
+        run_cmd cp -r "$this_dir/customizations" DAZSLE/DAZSLE/python
+    else
+        run_cmd ln -s "$this_dir/customizations" DAZSLE/DAZSLE/python
+    fi
 
     run_cmd scram b -j8
     run_cmd cmsenv

--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,7 @@ while true; do
     shift
 done
 
+echo "Running withEDITABLE: $EDITABLE"
 
 CMSSW_VER=CMSSW_14_0_6_patch1
 this_file="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"


### PR DESCRIPTION
Symlinking the customizations leads to problems when making tarballs for use in condor jobs. This PR copies the directory by default and adds the `-e` or `--editable` command line argument to symlink instead.